### PR TITLE
BUGFIX: Add separator for multi dimensional usages

### DIFF
--- a/Resources/Private/JavaScript/src/components/Inspector/NodeTypeUsage/NodeTypeUsageGroup.tsx
+++ b/Resources/Private/JavaScript/src/components/Inspector/NodeTypeUsage/NodeTypeUsageGroup.tsx
@@ -58,9 +58,14 @@ const NodeTypeUsageGroup: React.FC<NodeTypeUsageGroupProps> = ({ nodeTypeUsageLi
                         <td>{link.workspace}</td>
                         {showDimensions && (
                             <td>
-                                {Object.keys(link.dimensions).map(
-                                    (dimensionName) => dimensionName + ': ' + link.dimensions[dimensionName].join(', ')
-                                )}
+                                {Object.keys(link.dimensions).map((dimensionName, index) => {
+                                    let dimensionItem =
+                                        dimensionName + ': ' + link.dimensions[dimensionName].join(', ');
+                                    if (index < Object.keys(link.dimensions).length - 1) {
+                                        dimensionItem += ' | ';
+                                    }
+                                    return dimensionItem;
+                                })}
                             </td>
                         )}
                         <td>{link.nodeIdentifier}</td>


### PR DESCRIPTION
If you use more than one dimension, the dimension name is directly after the dimension value before. And that leads to a bad user experience as it is not good to read.

For instance, “country: pollanguage: pl”
With this change, we add a pipe and it will look like  that “country: pol | language: pl” in the usage table.

The comma as separator was already used if the dimension value has more than one item.