### PR TITLE
Autofix: BUG: Nodetypes  whose segments are below content nodetypes are not visible in the tree

### DIFF
--- a/Resources/Private/JavaScript/src/components/NodeTypeAnalysis/NodeTypeTree/NodeTypeTree.tsx
+++ b/Resources/Private/JavaScript/src/components/NodeTypeAnalysis/NodeTypeTree/NodeTypeTree.tsx
@@ -6,6 +6,7 @@ import { Tree } from '@neos-project/react-ui-components';
 
 import NodeTypeTreeNode from './NodeTypeTreeNode';
 import VendorSegmentTreeNode from './VendorSegmentTreeNode';
+import { nodeTypesState, treeDataState, hiddenNodeTypesState } from '../../../state';
 import { nodeTypesState, treeDataState } from '../../../state';
 
 const useStyles = createUseStyles({
@@ -17,6 +18,9 @@ const useStyles = createUseStyles({
 const NodeTypeTree: React.FC = () => {
     const classes = useStyles();
     const nodeTypes = useRecoilValue(nodeTypesState);
+    const hiddenNodeTypes = useRecoilValue(hiddenNodeTypesState);
+    const { treeData } = useRecoilValue(treeDataState);
+    const nodeTypes = useRecoilValue(nodeTypesState);
     const { treeData } = useRecoilValue(treeDataState);
 
     return (
@@ -24,6 +28,7 @@ const NodeTypeTree: React.FC = () => {
             {Object.keys(treeData)
                 .sort()
                 .map((segment, index) =>
+                    treeData[segment].nodeType && !hiddenNodeTypes.includes(treeData[segment].nodeType) ? (
                     treeData[segment].nodeType ? (
                         <NodeTypeTreeNode key={index} nodeType={nodeTypes[treeData[segment].nodeType]} />
                     ) : (

--- a/Resources/Private/JavaScript/src/components/NodeTypeAnalysis/SearchBox.tsx
+++ b/Resources/Private/JavaScript/src/components/NodeTypeAnalysis/SearchBox.tsx
@@ -6,6 +6,7 @@ import { SelectBox } from '@neos-project/react-ui-components';
 
 import { Action, useGraph, useIntl } from '../../core';
 import nodePathHelper from '../../helpers/nodePathHelper';
+import { nodeTypeFilterState, nodeTypesState, searchTermState, hiddenNodeTypesState } from '../../state';
 import { nodeTypeFilterState, nodeTypesState, searchTermState } from '../../state';
 import nodeTypeMatchesFilter from '../../helpers/nodeTypeFilter';
 import { FilterType } from '../../constants';
@@ -29,11 +30,14 @@ const useStyles = createUseStyles({
     },
 });
 
+function getOptionsForTerm(nodeTypes: NodeTypeConfigurations, searchTerm: string, nodeTypeFilter: FilterType, hiddenNodeTypes: string[]) {
 function getOptionsForTerm(nodeTypes: NodeTypeConfigurations, searchTerm: string, nodeTypeFilter: FilterType) {
     return Object.keys(nodeTypes)
         .filter((nodeTypeName) => {
             return (
                 (!searchTerm || nodeTypeName.toLowerCase().indexOf(searchTerm.toLowerCase()) >= 0) &&
+                nodeTypeMatchesFilter(nodeTypes[nodeTypeName], nodeTypeFilter) &&
+                (searchTerm !== '' || !hiddenNodeTypes.includes(nodeTypeName))
                 nodeTypeMatchesFilter(nodeTypes[nodeTypeName], nodeTypeFilter)
             );
         })
@@ -54,6 +58,11 @@ const SearchBox: React.FC = () => {
     const classes = useStyles();
     const { translate } = useIntl();
     const { dispatch } = useGraph();
+    const nodeTypes = useRecoilValue(nodeTypesState);
+    const [searchTerm, setSearchTerm] = useRecoilState(searchTermState);
+    const selectedFilter = useRecoilValue(nodeTypeFilterState);
+    const hiddenNodeTypes = useRecoilValue(hiddenNodeTypesState);
+    const options = getOptionsForTerm(nodeTypes, searchTerm, selectedFilter, hiddenNodeTypes);
     const nodeTypes = useRecoilValue(nodeTypesState);
     const [searchTerm, setSearchTerm] = useRecoilState(searchTermState);
     const selectedFilter = useRecoilValue(nodeTypeFilterState);


### PR DESCRIPTION
Update NodeTypeTree.tsx to filter out specific node types from the tree view, and modify SearchBox.tsx to include all node types in the search results. This change allows NodeType B to be found only via search while keeping NodeType A visible in the tree. 
> [!CAUTION]
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!
>
> The fix provided by Latta AI might not be complete and it can serve as an inspiration.

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission

If you no longer want Latta AI to attempt fixing issues on your repository, you can block this account.
    